### PR TITLE
Patch

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -68,7 +68,7 @@
 		<dc:source>http://shakespeare.mit.edu/lear/full.html</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/004135080</dc:source>
 		<meta property="se:production-notes">The main text is based on the MIT transcription and 1887 Victoria edition.</meta>
-		<meta property="se:word-count">28346</meta>
+		<meta property="se:word-count">28345</meta>
 		<meta property="se:reading-ease.flesch">82.95</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/King_Lear</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/william-shakespeare_king-lear</meta>

--- a/src/epub/text/act-1.xhtml
+++ b/src/epub/text/act-1.xhtml
@@ -966,7 +966,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">II</span>
 				</h3>
-				<p>The Earl of <b epub:type="z3998:persona">Gloucester’s</b> castle</p>
+				<p>The Earl of <b epub:type="z3998:persona">Gloucester’s</b> castle.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -1359,7 +1359,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">IV</span>
 				</h3>
-				<p>A hall in the same</p>
+				<p>A hall in the same.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -2154,7 +2154,7 @@
 									<br/>
 									<span>To temper clay. Yea, it is come to this?</span>
 									<br/>
-									<span>Let is be so: yet have I left a daughter,</span>
+									<span>Let it be so: yet have I left a daughter,</span>
 									<br/>
 									<span>Who, I am sure, is kind and comfortable:</span>
 									<br/>
@@ -2326,7 +2326,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">V</span>
 				</h3>
-				<p>Court before the same</p>
+				<p>Court before the same.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -2447,7 +2447,13 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">King Lear</td>
-							<td>O, let me not be mad, not mad, sweet heaven Keep me in temper: I would not be mad!</td>
+							<td epub:type="z3998:verse">
+								<p>
+									<span>O, let me not be mad, not mad, sweet heaven!</span>
+									<br/>
+									<span>Keep me in temper: I would not be mad!</span>
+								</p>
+							</td>
 						</tr>
 						<tr>
 							<td/>
@@ -2469,7 +2475,13 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">Fool</td>
-							<td>She that’s a maid now, and laughs at my departure, Shall not be a maid long, unless things be cut shorter. <i epub:type="z3998:stage-direction">Exeunt.</i></td>
+							<td epub:type="z3998:verse">
+								<p>
+									<span>She that’s a maid now, and laughs at my departure,</span>
+									<br/>
+									<span>Shall not be a maid long, unless things be cut shorter. <i epub:type="z3998:stage-direction">Exeunt.</i></span>
+								</p>
+							</td>
 						</tr>
 					</tbody>
 				</table>

--- a/src/epub/text/act-1.xhtml
+++ b/src/epub/text/act-1.xhtml
@@ -2458,7 +2458,7 @@
 						<tr>
 							<td/>
 							<td>
-								<i epub:type="z3998:stage-direction">Enter Gentleman.</i>
+								<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">Gentleman</b>.</i>
 							</td>
 						</tr>
 						<tr>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -607,7 +607,7 @@
 						<tr>
 							<td/>
 							<td>
-								<i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Enter</b> <b epub:type="z3998:persona">Edmund</b>, with his rapier drawn, <b epub:type="z3998:persona">Cornwall</b>, <b epub:type="z3998:persona">Regan</b>, <b epub:type="z3998:persona">Gloucester</b>, and Servants.</i>
+								<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">Edmund</b>, with his rapier drawn, <b epub:type="z3998:persona">Cornwall</b>, <b epub:type="z3998:persona">Regan</b>, <b epub:type="z3998:persona">Gloucester</b>, and Servants.</i>
 							</td>
 						</tr>
 						<tr>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -16,7 +16,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">I</span>
 				</h3>
-				<p><b epub:type="z3998:persona">Gloucester’s</b> castle</p>
+				<p><b epub:type="z3998:persona">Gloucester’s</b> castle.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -519,7 +519,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">II</span>
 				</h3>
-				<p>Before <b epub:type="z3998:persona">Gloucester’s</b> castle</p>
+				<p>Before <b epub:type="z3998:persona">Gloucester’s</b> castle.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -1030,7 +1030,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">III</span>
 				</h3>
-				<p>A wood</p>
+				<p>A wood.</p>
 				<table>
 					<tbody>
 						<tr>
@@ -1095,7 +1095,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">IV</span>
 				</h3>
-				<p>Before <b epub:type="z3998:persona">Gloucester’s</b> castle</p>
+				<p>Before <b epub:type="z3998:persona">Gloucester’s</b> castle.</p>
 				<table>
 					<tbody>
 						<tr>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -1107,7 +1107,7 @@
 						<tr>
 							<td/>
 							<td>
-								<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">King Lear</b>, <b epub:type="z3998:persona">Fool</b>, and Gentleman.</i>
+								<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">King Lear</b>, <b epub:type="z3998:persona">Fool</b>, and <b epub:type="z3998:persona">Gentleman</b>.</i>
 							</td>
 						</tr>
 						<tr>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -830,7 +830,7 @@
 						</tr>
 						<tr>
 							<td epub:type="z3998:persona">Edgar</td>
-							<td>Poor Tom; that eats the swimming frog, the toad, the tadpole, the wall-newt and the water; that in the fury of his heart, when the foul fiend rages, eats cow-dung for sallets; swallows the old rat and the ditch-dog; drinks the green mantle of the standing pool; who is whipped from tithing to tithing, and stock- punished, and imprisoned; who hath had three suits to his back, six shirts to his body, horse to ride, and weapon to wear;</td>
+							<td>Poor Tom; that eats the swimming frog, the toad, the tadpole, the wall-newt and the water; that in the fury of his heart, when the foul fiend rages, eats cow-dung for sallets; swallows the old rat and the ditch-dog; drinks the green mantle of the standing pool; who is whipped from tithing to tithing, and stock-punished, and imprisoned; who hath had three suits to his back, six shirts to his body, horse to ride, and weapon to wear;</td>
 						</tr>
 						<tr>
 							<td/>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -1533,7 +1533,7 @@
 							<td epub:type="z3998:persona">Cornwall</td>
 							<td epub:type="z3998:verse">
 								<p>
-									<span>Edmund, farewell. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Exeunt</b> <b epub:type="z3998:persona">Goneril</b>, <b epub:type="z3998:persona">Edmund</b>, and <b epub:type="z3998:persona">Oswald</b>.</i></span>
+									<span>Edmund, farewell. <i epub:type="z3998:stage-direction">Exeunt <b epub:type="z3998:persona">Goneril</b>, <b epub:type="z3998:persona">Edmund</b>, and <b epub:type="z3998:persona">Oswald</b>.</i></span>
 									<br/>
 									<span>Go seek the traitor Gloucester,</span>
 									<br/>
@@ -1875,7 +1875,7 @@
 								<p>
 									<span>Go thrust him out at gates, and let him smell</span>
 									<br/>
-									<span>His way to Dover. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Exit</b> one with <b epub:type="z3998:persona">Gloucester</b>.</i></span>
+									<span>His way to Dover. <i epub:type="z3998:stage-direction">Exit one with <b epub:type="z3998:persona">Gloucester</b>.</i></span>
 									<br/>
 									<span>How is’t, my lord? how look you?</span>
 								</p>
@@ -1891,7 +1891,7 @@
 									<br/>
 									<span>Upon the dunghill. Regan, I bleed apace:</span>
 									<br/>
-									<span>Untimely comes this hurt: give me your arm. <i epub:type="z3998:stage-direction"><b epub:type="z3998:persona">Exit</b> <b epub:type="z3998:persona">Cornwall</b>, led by <b epub:type="z3998:persona">Regan</b>.</i></span>
+									<span>Untimely comes this hurt: give me your arm. <i epub:type="z3998:stage-direction">Exit <b epub:type="z3998:persona">Cornwall</b>, led by <b epub:type="z3998:persona">Regan</b>.</i></span>
 								</p>
 							</td>
 						</tr>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -22,7 +22,7 @@
 						<tr>
 							<td/>
 							<td>
-								<i epub:type="z3998:stage-direction">Storm still. Enter <b epub:type="z3998:persona">Kent</b> and a Gentleman, meeting.</i>
+								<i epub:type="z3998:stage-direction">Storm still. Enter <b epub:type="z3998:persona">Kent</b> and a <b epub:type="z3998:persona">Gentleman</b>, meeting.</i>
 							</td>
 						</tr>
 						<tr>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -16,7 +16,7 @@
 					<span epub:type="label">Scene</span>
 					<span epub:type="ordinal z3998:roman">I</span>
 				</h3>
-				<p>The heath</p>
+				<p>The heath.</p>
 				<table>
 					<tbody>
 						<tr>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -1958,7 +1958,7 @@
 							<td epub:type="z3998:persona">Edgar</td>
 							<td epub:type="z3998:verse">
 								<p>
-									<span>I thank you, sir. <i epub:type="z3998:stage-direction">Exit Gentleman.</i></span>
+									<span>I thank you, sir. <i epub:type="z3998:stage-direction">Exit <b epub:type="z3998:persona">Gentleman</b>.</i></span>
 								</p>
 							</td>
 						</tr>
@@ -2279,7 +2279,7 @@
 								<p>
 									<span>Then be’t so, my good lord.</span>
 									<br/>
-									<span><i epub:type="z3998:stage-direction">To the Doctor.</i> How does the king?</span>
+									<span><i epub:type="z3998:stage-direction">To the <b epub:type="z3998:persona">Doctor</b>.</i> How does the king?</span>
 								</p>
 							</td>
 						</tr>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -48,7 +48,7 @@
 									<span>Owes nothing to thy blasts. But who comes here?</span>
 									<br/>
 									<span>
-										<i><b epub:type="z3998:persona">Enter</b> <b epub:type="z3998:persona">Gloucester</b>, led by an <b epub:type="z3998:persona">Old Man</b>.</i>
+										<i>Enter <b epub:type="z3998:persona">Gloucester</b>, led by an <b epub:type="z3998:persona">Old Man</b>.</i>
 									</span>
 									<br/>
 									<span>My father, poorly led? World, world, O world!</span>

--- a/src/epub/text/act-5.xhtml
+++ b/src/epub/text/act-5.xhtml
@@ -35,7 +35,7 @@
 									<br/>
 									<span>To change the course: he’s full of alteration</span>
 									<br/>
-									<span>And self-reproving: bring his constant pleasure. <i epub:type="z3998:stage-direction">To a Gentleman, who goes out.</i></span>
+									<span>And self-reproving: bring his constant pleasure. <i epub:type="z3998:stage-direction">To a <b epub:type="z3998:persona">Gentleman</b>, who goes out.</i></span>
 								</p>
 							</td>
 						</tr>
@@ -725,7 +725,7 @@
 									<br/>
 									<span>On capital treason; and, in thine attaint,</span>
 									<br/>
-									<span>This gilded serpent <i epub:type="z3998:stage-direction">Pointing to Goneril.</i></span>
+									<span>This gilded serpent <i epub:type="z3998:stage-direction">Pointing to <b epub:type="z3998:persona">Goneril</b>.</i></span>
 									<br/>
 									<span>For your claim, fair sister,</span>
 									<br/>
@@ -1297,7 +1297,7 @@
 									<br/>
 									<span>This judgment of the heavens, that makes us tremble,</span>
 									<br/>
-									<span>Touches us not with pity. <i epub:type="z3998:stage-direction">Exit Gentleman.</i></span>
+									<span>Touches us not with pity. <i epub:type="z3998:stage-direction">Exit <b epub:type="z3998:persona">Gentleman</b>.</i></span>
 								</p>
 							</td>
 						</tr>


### PR DESCRIPTION
I checked all the transcription errors against the scans.

"Doctor" and "Gentleman" aren't set in small caps in the stage directions in the scans, but the producer of this ebook tagged most of them with `<b epub:type="z3998:persona>`, which is correct according to 7.6.6.2 and 7.6.3, because they have speaking roles. I added those semantics to the remainder in b92fd37.